### PR TITLE
SAGE-1285: introduce waggle-powercycle tools

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,16 @@
+name: CI/CD
+on: push
+jobs:
+  build:
+    name: Build and Release
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build deb
+        run: ./build.sh
+      - name: Create release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: output/*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Waggle Powercycle
+
+Wild Sage Node shutdown & reboot tools to ensure all compute units and accessories are included in the shutdown / reboot sequence.  Includes 2 tools:
+
+1. `waggle-powercycle` command to initiate shutdown or reboot (default) of the WSN
+2. `waggle-power-up` service that is auto-run on the NX core boot-up to ensure the power supply unit (PSU) ports are enabled (powering the WSN agent compute units and accessories)
+
+## Usage (`waggle-powercycle`)
+
+To reboot the WSN execute the following command:
+
+```
+waggle-powercycle
+```
+
+To shutdown the WSN execute the following command:
+
+```
+waggle-powercycle -s
+```
+
+> *Note*: the `waggle-powercycle` command can be run in 'dry-run' mode by issuing the `-d` argument

--- a/ROOTFS/etc/systemd/system/waggle-power-up.service
+++ b/ROOTFS/etc/systemd/system/waggle-power-up.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Waggle Power Up Service
+# Bring-up local lan that dnsmasq wants
+Wants=dnsmasq.service
+Before=dnsmasq.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/waggle-set-psu-state on on
+
+[Install]
+WantedBy=multi-user.target

--- a/ROOTFS/usr/bin/waggle-powercycle
+++ b/ROOTFS/usr/bin/waggle-powercycle
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+print_help() {
+  echo """
+usage: $0 [-s] [-d]
+
+Perform a safe reboot (or shutdown) of the Wild Sage Node by executing shutdown / reboot on all
+agents (i.e. RPi) before executing power cycle on the NX core.
+
+  -s : execute shutdown instead [defaul: reboot]
+  -d : (optional) dry-run mode (don't perform shutdown/reboot) [default: False]
+"""
+}
+
+AGENTS=(
+  "ws-rpi"
+  "ws-nxagent"
+)
+
+SHUTDOWN=
+DRY=
+nx_action="reboot"
+nx_cmd="reboot"
+while getopts "sd?" opt; do
+  case $opt in
+    s) SHUTDOWN=1
+      nx_action="shutdown"
+      nx_cmd="poweroff"
+      ;;
+    d) DRY=1
+       echo "** DRY RUN MODE **"
+      ;;
+    ?|*)
+      print_help
+      exit 1
+      ;;
+  esac
+done
+
+echo "Executing system ${nx_action}"
+
+# always shutdown the agents, on system power-up the agents will be restarted
+for agent in "${AGENTS[@]}"; do
+  echo "- shutdown $agent..."
+  if [ -z "${DRY}" ]; then
+    if ! ssh -q $agent 'systemctl poweroff'; then
+      echo "WARNING: unable to shutdown agent [$agent]"
+    fi
+  fi
+  echo "- shutdown $agent...DONE"
+done
+
+# always power off the PSU ports, on system power-up the PSU ports will be powered on
+echo "- power off PSU ports..."
+if [ -z "${DRY}" ]; then
+  if ! waggle-set-psu-state off off; then
+    echo "WARNING: unable turn off PSU outputs"
+  fi
+fi
+echo "- power off PSU ports...DONE"
+
+# reboot / shutdown the NX core
+echo "- ${nx_action} nx core..."
+if [ -z "${DRY}" ]; then
+  if ! systemctl ${nx_cmd}; then
+    echo "ERROR: unable ${nx_action} NX core"
+  fi
+fi
+echo "- ${nx_action} nx core...DONE"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+docker run --rm \
+  -e NAME="waggle-powercycle" \
+  -e DESCRIPTION="Waggle Power Cycle Tools" \
+  -e "MAINTAINER=sagecontinuum.org" \
+  -e "DEPENDS=waggle-common-tools (>= 0.2.0)" \
+  -v "$PWD:/repo" \
+  waggle/waggle-deb-builder:0.3.1

--- a/deb/install/postinst
+++ b/deb/install/postinst
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+case "${1}" in
+  configure)
+    echo "Enabling Waggle Power-up Service"
+    systemctl enable waggle-power-up.service
+    ;;
+esac

--- a/deb/install/prerm
+++ b/deb/install/prerm
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl disable waggle-power-up.service || true


### PR DESCRIPTION
- includes waggle-powercycle command for reboot / shutdown of WSN
- includes power-on service to ensure the PSU outputs are enabled